### PR TITLE
Always convert the input to uppercases.

### DIFF
--- a/src/Util/BunqEnum.php
+++ b/src/Util/BunqEnum.php
@@ -26,6 +26,7 @@ abstract class BunqEnum
      */
     public function __construct($choice)
     {
+        $choice = strtoupper($choice);
         if (isset($this->supportedChoices[$choice])) {
             $this->choice = $choice;
         } else {


### PR DESCRIPTION
Always convert the input to uppercases. Because I don't want to think about lowercase or uppercase input.