### PR TITLE
#5 Allow setting a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,11 @@ $apiContext = ApiContext::restore($fileName);
 to/restored from the `bunq.conf` file in the same folder with your script.
 
 ##### Proxy
-
 You can use a proxy with the bunq PHP SDK. This option must be a string. This proxy will be used for all requests done with
-the SDK. You will be prompted to provide a proxy URL when using the interactive installation script.
+the context for which it was provided. You will be prompted to provide a proxy URL when using the interactive installation script.
 
 ```php
-$proxyUrl = 'socks5://localhost:1080'; // The proxy for all requests, leave empty to disable
+$proxyUrl = 'socks5://localhost:1080'; // The proxy for all requests, null to disable
 
 $apiContext = ApiContext::create(
     ...

--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ $apiContext = ApiContext::restore($fileName);
 **Tip:** both saving and restoring the context can be done without any arguments. In this case the context will be saved
 to/restored from the `bunq.conf` file in the same folder with your script.
 
+##### Proxy
+
+You can use a proxy with the bunq PHP SDK. This option must be a string. This proxy will be used for all requests done with
+the SDK. You will be prompted to provide a proxy URL when using the interactive installation script.
+
+```php
+$proxyUrl = 'socks5://localhost:1080'; // The proxy for all requests, leave empty to disable
+
+$apiContext = ApiContext::create(
+    ...
+    $proxyUrl
+);
+```
+
 #### Safety considerations
 The file storing the context details (i.e. `bunq.conf`) is a key to your account. Anyone having access to it is able to
 perform any Public API actions with your account. Therefore, we recommend choosing a truly safe place to store it.

--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -170,6 +170,8 @@ class ApiContext
 
         if (isset($contextJson[self::FIELD_PROXY_URL])) {
             $apiContext->proxyUrl = $contextJson[self::FIELD_PROXY_URL];
+        } else {
+            $apiContext->proxyUrl = null;
         }
 
         $apiContext->installationContext = InstallationContext::restore($contextJson[self::FIELD_INSTALLATION_CONTEXT]);

--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -39,6 +39,7 @@ class ApiContext
     const FIELD_SESSION_CONTEXT = 'session_context';
     const FIELD_ENVIRONMENT_TYPE = 'environment_type';
     const FIELD_API_KEY = 'api_key';
+    const FIELD_PROXY_URL = 'proxy_url';
 
     /**
      * Dummy ID to pass to Session endpoint.
@@ -67,6 +68,9 @@ class ApiContext
     /** @var InstallationContext */
     protected $installationContext;
 
+    /** @var string */
+    protected $proxyUrl;
+
     /**
      */
     private function __construct()
@@ -78,6 +82,7 @@ class ApiContext
      * @param string $apiKey
      * @param string $description
      * @param string[] $permittedIps
+     * @param string|null $proxyUrl
      *
      * @return static
      */
@@ -85,11 +90,13 @@ class ApiContext
         BunqEnumApiEnvironmentType $environmentType,
         $apiKey,
         $description,
-        array $permittedIps = []
+        array $permittedIps = [],
+        $proxyUrl = null
     ) {
         $apiContext = new static();
         $apiContext->environmentType = $environmentType;
         $apiContext->apiKey = $apiKey;
+        $apiContext->proxyUrl = $proxyUrl;
         $apiContext->initialize($description, $permittedIps);
 
         return $apiContext;
@@ -160,6 +167,11 @@ class ApiContext
         $contextJson = self::getContextJsonString($fileName);
         $apiContext->environmentType = new BunqEnumApiEnvironmentType($contextJson[self::FIELD_ENVIRONMENT_TYPE]);
         $apiContext->apiKey = $contextJson[self::FIELD_API_KEY];
+
+        if (isset($contextJson[self::FIELD_PROXY_URL])) {
+            $apiContext->proxyUrl = $contextJson[self::FIELD_PROXY_URL];
+        }
+
         $apiContext->installationContext = InstallationContext::restore($contextJson[self::FIELD_INSTALLATION_CONTEXT]);
         $apiContext->sessionContext = SessionContext::restore($contextJson[self::FIELD_SESSION_CONTEXT]);
 
@@ -292,6 +304,7 @@ class ApiContext
             self::FIELD_API_KEY => $this->getApiKey(),
             self::FIELD_ENVIRONMENT_TYPE => $this->getEnvironmentType()->getChoiceString(),
             self::FIELD_INSTALLATION_CONTEXT => $this->getInstallationContext(),
+            self::FIELD_PROXY_URL => $this->getProxyUrlOrNull(),
             self::FIELD_SESSION_CONTEXT => $this->getSessionContext(),
         ];
 
@@ -328,6 +341,14 @@ class ApiContext
     public function getEnvironmentType()
     {
         return $this->environmentType;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProxyUrlOrNull()
+    {
+        return $this->proxyUrl;
     }
 
     /**

--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -306,7 +306,7 @@ class ApiContext
             self::FIELD_API_KEY => $this->getApiKey(),
             self::FIELD_ENVIRONMENT_TYPE => $this->getEnvironmentType()->getChoiceString(),
             self::FIELD_INSTALLATION_CONTEXT => $this->getInstallationContext(),
-            self::FIELD_PROXY_URL => $this->getProxyUrlOrNull(),
+            self::FIELD_PROXY_URL => $this->getProxy(),
             self::FIELD_SESSION_CONTEXT => $this->getSessionContext(),
         ];
 
@@ -346,9 +346,9 @@ class ApiContext
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getProxyUrlOrNull()
+    public function getProxy()
     {
         return $this->proxyUrl;
     }

--- a/src/Http/ApiClient.php
+++ b/src/Http/ApiClient.php
@@ -163,7 +163,7 @@ class ApiClient
                     self::OPTION_CURL => [
                         CURLOPT_PINNEDPUBLICKEY => $this->determinePinnedServerPublicKey(),
                     ],
-                    self::OPTION_PROXY => $this->apiContext->getProxyUrlOrNull(),
+                    self::OPTION_PROXY => $this->apiContext->getProxy(),
                 ]
             );
         }

--- a/src/Http/ApiClient.php
+++ b/src/Http/ApiClient.php
@@ -82,6 +82,7 @@ class ApiClient
     const OPTION_CURL = 'curl';
     const OPTION_DEBUG = 'debug';
     const OPTION_HANDLER = 'handler';
+    const OPTION_PROXY = 'proxy';
     const OPTION_VERIFY = 'verify';
 
     /** @var Client */
@@ -161,7 +162,8 @@ class ApiClient
                     self::OPTION_VERIFY => true,
                     self::OPTION_CURL => [
                         CURLOPT_PINNEDPUBLICKEY => $this->determinePinnedServerPublicKey(),
-                    ]
+                    ],
+                    self::OPTION_PROXY => $this->apiContext->getProxyUrlOrNull(),
                 ]
             );
         }

--- a/src/Util/InstallationUtil.php
+++ b/src/Util/InstallationUtil.php
@@ -28,6 +28,7 @@ final class InstallationUtil
      */
     const PROMPT_ENVIRONMENT = 'Choose an environment (SANDBOX/PRODUCTION): ';
     const PROMPT_API_KEY = 'Please provide your api key: ';
+    const PROMPT_PROXY_URL = 'Provide a proxy url, leave empty for no proxy (default: no proxy): ';
     const PROMPT_DESCRIPTION = 'Provide a device description: ';
     const PROMPT_PERMITTED_IPS = 'Provide a list of comma-separated IPs (or leave empty for current IP): ';
     const PROMPT_CONTEXT_FILE = 'Provide a file where the bunq api context will be saved (default: bunq.conf): ';
@@ -37,6 +38,7 @@ final class InstallationUtil
      */
     const PROPERTY_ENVIRONMENT_TYPE = 'environmentType';
     const PROPERTY_API_KEY = 'apiKey';
+    const PROPERTY_PROXY_URL = 'proxyUrl';
     const METHOD_INITIALIZE_INSTALLATION_CONTEXT = 'initializeInstallationContext';
     const METHOD_REGISTER_DEVICE = 'registerDevice';
     const METHOD_INITIALIZE_SESSION_CONTEXT = 'initializeSessionContext';
@@ -72,6 +74,9 @@ final class InstallationUtil
                 self::ERROR_EMPTY_API_KEY
             );
             static::setPrivateProperty($context, self::PROPERTY_API_KEY, $apiKey);
+
+            $proxyUrl = static::readLineOrNull(self::PROMPT_PROXY_URL);
+            static::setPrivateProperty($context, self::PROPERTY_PROXY_URL, $proxyUrl);
 
             $methodInitializeInstallationContext = static::createAccessibleReflectionMethod(
                 ApiContext::class,


### PR DESCRIPTION
Save the proxy in the ApiContext. Allow an api context to not contain a proxy.

Fixes #5