### PR TITLE
Fixes #36 on php5.6

### DIFF
--- a/example/api_context_save_example.php
+++ b/example/api_context_save_example.php
@@ -15,5 +15,6 @@ const API_KEY = '### Your API key ###'; // Insert your API key here.
 const DEVICE_DESCRIPTION = 'Server 1';
 const PERMITTED_IPS = [];
 
+date_default_timezone_set('UTC'); // When using php5.6
 $apiContext = ApiContext::create(BunqEnumApiEnvironmentType::SANDBOX(), API_KEY, DEVICE_DESCRIPTION);
 $apiContext->save(ApiContext::FILENAME_CONFIG_DEFAULT);

--- a/example/api_context_save_example.php
+++ b/example/api_context_save_example.php
@@ -15,6 +15,5 @@ const API_KEY = '### Your API key ###'; // Insert your API key here.
 const DEVICE_DESCRIPTION = 'Server 1';
 const PERMITTED_IPS = [];
 
-date_default_timezone_set('UTC'); // When using php5.6
 $apiContext = ApiContext::create(BunqEnumApiEnvironmentType::SANDBOX(), API_KEY, DEVICE_DESCRIPTION);
 $apiContext->save(ApiContext::FILENAME_CONFIG_DEFAULT);

--- a/src/Model/BunqModel.php
+++ b/src/Model/BunqModel.php
@@ -35,16 +35,22 @@ abstract class BunqModel implements \JsonSerializable
     /**
      * Type constants.
      */
-    const SCALAR_TYPES = [
-        self::SCALAR_TYPE_STRING => true,
-        self::SCALAR_TYPE_BOOL => true,
-        self::SCALAR_TYPE_INT => true,
-        self::SCALAR_TYPE_FLOAT => true
-    ];
     const SCALAR_TYPE_STRING = 'string';
     const SCALAR_TYPE_BOOL = 'bool';
     const SCALAR_TYPE_INT = 'int';
     const SCALAR_TYPE_FLOAT = 'float';
+
+    /**
+     * Set of the PHP scalar types. Mimicking a constant, and therefore should be used with self::.
+     *
+     * @var bool[]
+     */
+    private static $scalarTypes = [
+        self::SCALAR_TYPE_STRING => true,
+        self::SCALAR_TYPE_BOOL => true,
+        self::SCALAR_TYPE_INT => true,
+        self::SCALAR_TYPE_FLOAT => true,
+    ];
 
     /**
      * @var string[]
@@ -177,7 +183,7 @@ abstract class BunqModel implements \JsonSerializable
      */
     private static function isTypeScalar($type)
     {
-        return isset(self::SCALAR_TYPES[$type]);
+        return isset(self::$scalarTypes[$type]);
     }
 
     /**


### PR DESCRIPTION
This should fix the error shown in #36.

However the `avatar` fatal is still present when using `/sdk_php/src/Model/Generated/MonetaryAccountBank.php` 🤔 

Tests passes on`php7.1`.