### PR TITLE
toJson() fails on ApiContext of an user person due to session context

### DIFF
--- a/src/Model/Core/SessionServer.php
+++ b/src/Model/Core/SessionServer.php
@@ -74,7 +74,7 @@ class SessionServer extends BunqModel
     /**
      * @return UserCompany
      */
-    public function getUserCompany(): UserCompany
+    public function getUserCompany()
     {
         return $this->userCompany;
     }
@@ -82,7 +82,7 @@ class SessionServer extends BunqModel
     /**
      * @return UserPerson
      */
-    public function getUserPerson(): UserPerson
+    public function getUserPerson()
     {
         return $this->userPerson;
     }


### PR DESCRIPTION
# Context
#56 

# What has been done
- Removed the strict types from the getters in the SessionContext class.

# Notes
Once the Bunq PHP SDK drops 7.0 support they can use PHP7.1 nullable strict return types.
Example : `getUserCompany(): ?UserCompany`

fixes #56 