### PR TITLE
Feature/is expired#58

### DIFF
--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -273,7 +273,7 @@ class ApiContext
      */
     public function ensureSessionActive()
     {
-        if ($this->isSessionActive()) {
+        if (!$this->isSessionActive()) {
             $this->resetSession();
         }
     }
@@ -290,7 +290,7 @@ class ApiContext
         $timeExpiry = $this->sessionContext->getExpiryTime()->getTimestamp();
         $timeToExpiry = $timeExpiry - time();
 
-        return $timeToExpiry < self::TIME_TO_SESSION_EXPIRY_MINIMUM_SECONDS;
+        return $timeToExpiry > self::TIME_TO_SESSION_EXPIRY_MINIMUM_SECONDS;
     }
 
     /**

--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -273,7 +273,7 @@ class ApiContext
      */
     public function ensureSessionActive()
     {
-        if (!is_null($this->sessionContext) && $this->isSessionExpired()) {
+        if ($this->isSessionExpired()) {
             $this->resetSession();
         }
     }
@@ -283,9 +283,14 @@ class ApiContext
      */
     public function isSessionExpired(): bool
     {
-        $timeExpiry = $this->sessionContext->getExpiryTime()->getTimestamp();
+        if (is_null($this->sessionContext)){
+            return false;
+        }
 
-        return is_null($this->sessionContext) || $timeExpiry - time() < self::TIME_TO_SESSION_EXPIRY_MINIMUM_SECONDS;
+        $timeExpiry = $this->sessionContext->getExpiryTime()->getTimestamp();
+        $timeToExpiry = $timeExpiry - time();
+
+        return $timeToExpiry < self::TIME_TO_SESSION_EXPIRY_MINIMUM_SECONDS;
     }
 
     /**

--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -273,17 +273,15 @@ class ApiContext
      */
     public function ensureSessionActive()
     {
-        if (!is_null($this->sessionContext) && $this->isExpired()) {
+        if (!is_null($this->sessionContext) && $this->isSessionExpired()) {
             $this->resetSession();
         }
     }
 
     /**
-     * Checks if the session has expired
-     *
      * @return bool
      */
-    public function isExpired()
+    public function isSessionExpired(): bool
     {
         $timeExpiry = $this->sessionContext->getExpiryTime()->getTimestamp();
 

--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -273,15 +273,21 @@ class ApiContext
      */
     public function ensureSessionActive()
     {
-        if (is_null($this->sessionContext)) {
-            return;
-        }
-
-        $timeExpiry = $this->sessionContext->getExpiryTime()->getTimestamp();
-
-        if ($timeExpiry - time() < self::TIME_TO_SESSION_EXPIRY_MINIMUM_SECONDS) {
+        if (!is_null($this->sessionContext) && $this->isExpired()) {
             $this->resetSession();
         }
+    }
+
+    /**
+     * Checks if the session has expired
+     *
+     * @return bool
+     */
+    public function isExpired()
+    {
+        $timeExpiry = $this->sessionContext->getExpiryTime()->getTimestamp();
+
+        return is_null($this->sessionContext) || $timeExpiry - time() < self::TIME_TO_SESSION_EXPIRY_MINIMUM_SECONDS;
     }
 
     /**

--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -273,7 +273,7 @@ class ApiContext
      */
     public function ensureSessionActive()
     {
-        if ($this->isSessionExpired()) {
+        if ($this->isSessionActive()) {
             $this->resetSession();
         }
     }
@@ -281,7 +281,7 @@ class ApiContext
     /**
      * @return bool
      */
-    public function isSessionExpired(): bool
+    public function isSessionActive(): bool
     {
         if (is_null($this->sessionContext)){
             return false;

--- a/src/Http/ApiClient.php
+++ b/src/Http/ApiClient.php
@@ -21,17 +21,17 @@ use Psr\Http\Message\ResponseInterface;
 class ApiClient
 {
     /**
-     * These are the endpoints where there is no need to have an active session for the request
-     * to succeed.
+     * Endpoints not requiring active session for the request to succeed
      */
-    const SESSION_SERVER_URL = "session-server";
-    const DEVICE_SERVER_URL = "device-server";
-    const INSTALLATION_URL = "installation";
 
-    const URLS_TO_NOT_ENSURE_ACTIVE_SESSION = [
-        self::INSTALLATION_URL,
-        self::DEVICE_SERVER_URL,
-        self::SESSION_SERVER_URL];
+    const URIS_NOT_REQUIRING_ACTIVE_SESSION = [
+        self::INSTALLATION_URL => true,
+        self::DEVICE_SERVER_URL => true,
+        self::SESSION_SERVER_URL => true,
+    ];
+    const SESSION_SERVER_URL = 'session-server';
+    const DEVICE_SERVER_URL = 'device-server';
+    const INSTALLATION_URL = 'installation';
 
     /**
      * Error constants.
@@ -195,7 +195,7 @@ class ApiClient
      */
     private function initialize(string $uri)
     {
-        if (!in_array($uri, self::URLS_TO_NOT_ENSURE_ACTIVE_SESSION, true)) {
+        if (!isset(self::URIS_NOT_REQUIRING_ACTIVE_SESSION[$uri])) {
             $this->apiContext->ensureSessionActive();
         }
 

--- a/src/Http/ApiClient.php
+++ b/src/Http/ApiClient.php
@@ -13,12 +13,26 @@ use bunq\Util\BunqEnumApiEnvironmentType;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Uri;
+use phpDocumentor\Reflection\Types\Self_;
 use Psr\Http\Message\ResponseInterface;
 
 /**
  */
 class ApiClient
 {
+    /**
+     * These are the endpoints where there is no need to have an active session for the request
+     * to succeed.
+     */
+    const SESSION_SERVER_URL = "session-server";
+    const DEVICE_SERVER_URL = "device-server";
+    const INSTALLATION_URL = "installation";
+
+    const URLS_TO_NOT_ENSURE_ACTIVE_SESSION = [
+        self::INSTALLATION_URL,
+        self::DEVICE_SERVER_URL,
+        self::SESSION_SERVER_URL];
+
     /**
      * Error constants.
      */
@@ -166,7 +180,7 @@ class ApiClient
         array $params,
         array $customHeaders
     ): BunqResponseRaw {
-        $this->initialize();
+        $this->initialize($uri);
 
         $response = $this->httpClient->request(
             $method,
@@ -179,9 +193,12 @@ class ApiClient
 
     /**
      */
-    private function initialize()
+    private function initialize(string $uri)
     {
-        $this->apiContext->ensureSessionActive();
+        if (!in_array($uri, self::URLS_TO_NOT_ENSURE_ACTIVE_SESSION, true)) {
+            $this->apiContext->ensureSessionActive();
+        }
+
         $this->initializeHttpClient();
     }
 

--- a/src/Http/ApiClient.php
+++ b/src/Http/ApiClient.php
@@ -21,17 +21,16 @@ use Psr\Http\Message\ResponseInterface;
 class ApiClient
 {
     /**
-     * Endpoints not requiring active session for the request to succeed
+     * Endpoints not requiring active session for the request to succeed.
      */
-
     const URIS_NOT_REQUIRING_ACTIVE_SESSION = [
-        self::INSTALLATION_URL => true,
         self::DEVICE_SERVER_URL => true,
+        self::INSTALLATION_URL => true,
         self::SESSION_SERVER_URL => true,
     ];
-    const SESSION_SERVER_URL = 'session-server';
     const DEVICE_SERVER_URL = 'device-server';
     const INSTALLATION_URL = 'installation';
+    const SESSION_SERVER_URL = 'session-server';
 
     /**
      * Error constants.


### PR DESCRIPTION
## Context 
#58 

## What has been done
This pr introduces a new way to handle `SessionContext`. Now it is possible to do the following:

```
if (!$apiContext->isSessionActive()) {
    $apiContext->resetSession();
    $apiContext->save();
}
```

This way there is no saving an unchanged context.

Closes #58  