### PR TITLE
Return static. (bunq/sdk_php#73)

### DIFF
--- a/src/Model/Core/BunqModel.php
+++ b/src/Model/Core/BunqModel.php
@@ -87,9 +87,9 @@ abstract class BunqModel implements JsonSerializable
     /**
      * @param string $json
      *
-     * @return BunqModel
+     * @return static
      */
-    public static function createFromJsonString(string $json): BunqModel
+    public static function createFromJsonString(string $json)
     {
         $responseArray = ModelUtil::deserializeResponseArray($json);
 

--- a/src/Model/Core/BunqModel.php
+++ b/src/Model/Core/BunqModel.php
@@ -89,7 +89,7 @@ abstract class BunqModel implements JsonSerializable
      *
      * @return static
      */
-    public static function createFromJsonString(string $json)
+    public static function createFromJsonString(string $json): BunqModel
     {
         $responseArray = ModelUtil::deserializeResponseArray($json);
 


### PR DESCRIPTION
This ensure that the base class is returned instead of BunqModel.

Closes bunq/sdk_php#73