### PR TITLE
Allow permitted IPs to be null in the interactive installer

### DIFF
--- a/src/Util/InstallationUtil.php
+++ b/src/Util/InstallationUtil.php
@@ -190,7 +190,7 @@ final class InstallationUtil
      *
      * @return string[]
      */
-    private static function formatIps(string $permittedIpsInput): array
+    private static function formatIps(string $permittedIpsInput = null): array
     {
         if (is_null($permittedIpsInput)) {
             $permittedIps = [];


### PR DESCRIPTION
When running `vendor/bin/bunq-install` the following error occurred:

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to bunq\Util\InstallationUtil::formatIps() must be of the type string, null given, called in /Users/mbernson/bunqtest/vendor/bunq/sdk_php/src/Util/InstallationUtil.php on line 88 and defined in /Users/mbernson/bunqtest/vendor/bunq/sdk_php/src/Util/InstallationUtil.php:193
Stack trace:
#0 /Users/mbernson/bunqtest/vendor/bunq/sdk_php/src/Util/InstallationUtil.php(88): bunq\Util\InstallationUtil::formatIps(NULL)
#1 /Users/mbernson/bunqtest/vendor/bunq/sdk_php/bin/bunq-install(16): bunq\Util\InstallationUtil::interactiveInstall()
#2 {main}
  thrown in /Users/mbernson/bunqtest/vendor/bunq/sdk_php/src/Util/InstallationUtil.php on line 193

Fatal error: Uncaught TypeError: Argument 1 passed to bunq\Util\InstallationUtil::formatIps() must be of the type string, null given, called in /Users/mbernson/bunqtest/vendor/bunq/sdk_php/src/Util/InstallationUtil.php on line 88 and defined in /Users/mbernson/bunqtest/vendor/bunq/sdk_php/src/Util/InstallationUtil.php on line 193

TypeError: Argument 1 passed to bunq\Util\InstallationUtil::formatIps() must be of the type string, null given, called in /Users/mbernson/bunqtest/vendor/bunq/sdk_php/src/Util/InstallationUtil.php on line 88 in /Users/mbernson/bunqtest/vendor/bunq/sdk_php/src/Util/InstallationUtil.php on line 193

Call Stack:
    0.0003     354664   1. {main}() /Users/mbernson/bunqtest/vendor/bunq/sdk_php/bin/bunq-install:0
    0.0044     677128   2. bunq\Util\InstallationUtil::interactiveInstall() /Users/mbernson/bunqtest/vendor/bunq/sdk_php/bin/bunq-install:16
    9.4677    1736472   3. bunq\Util\InstallationUtil::formatIps() /Users/mbernson/bunqtest/vendor/bunq/sdk_php/src/Util/InstallationUtil.php:88
```

Error occurred on PHP 7.0.26, fix tested on PHP 7.0.26