### PR TITLE
Fix BunqException namespace

### DIFF
--- a/src/Model/Generated/Endpoint/MonetaryAccount.php
+++ b/src/Model/Generated/Endpoint/MonetaryAccount.php
@@ -3,7 +3,7 @@
 namespace bunq\Model\Generated\Endpoint;
 
 use bunq\Context\ApiContext;
-use bunq\exception\BunqException;
+use bunq\Exception\BunqException;
 use bunq\Http\ApiClient;
 use bunq\Http\BunqResponse;
 use bunq\Model\Core\AnchorObjectInterface;


### PR DESCRIPTION
PHP is case-sensitive, and so Exception should be uppercased to point to the correct BunqException.

[//]: # (Thanks for opening this pull request! Before you proceed please make sure that you have an issue that explains what this pull request will do.
         Make sure that all your commits link to this issue e.g. "My commit. \(bunq/sdk_php#<issue nr>\)".
         If this pull request is changing files that are located in "src/Model/Generated" then this pull request will be closed as these files must/can only be changed on bunq's side.)
         
## This PR closes/fixes the following issues: N/A
[//]: # (If for some reason your pull request does not require a test case you can just mark this box as checked and explain why it does not require a test case.)
 - Closes bunq/sdk_php#
    - [x] Tested
