### PR TITLE
Support PHP 7.4  \(bunq/sdk_php#211\)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.0.13",
+        "php": "^7.4",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
@@ -40,8 +40,8 @@
         "brianium/paratest": "^1.1",
         "friendsofphp/php-cs-fixer": "^2.4",
         "jakub-onderka/php-parallel-lint": "^0.9.2",
-        "phpro/grumphp": "^0.11.6",
-        "phpstan/phpstan": "^0.8",
+        "phpro/grumphp": "^1.4",
+        "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": "^6.0.13",
         "sebastian/phpcpd": "^3.0",
         "sensiolabs/security-checker": "^5.0"
@@ -52,7 +52,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "7.0.13"
+            "php": "7.4"
         }
     },
     "scripts": {

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,4 +1,4 @@
-parameters:
+grumphp:
     bin_dir: "./vendor/bin"
     git_dir: "."
     hide_circumvention_tip: false


### PR DESCRIPTION
This MR will update the composer.json to support PHP 7.4. 
         
## This PR closes/fixes the following issues:
[x]: # (If for some reason your pull request does not require a test case you can just mark this box as checked and explain why it does not require a test case.)
 - Upgrade to PHP 7.4#
    - [ ] Tested
 - Update phpro/grumphp package#
    - [ ] Tested
 - Update phpstan/phpstan package#
    - [ ] Tested
