### PR TITLE
Replace parse_query with Query::parse because it's deprecated

### DIFF
--- a/src/Http/Pagination.php
+++ b/src/Http/Pagination.php
@@ -2,7 +2,7 @@
 namespace bunq\Http;
 
 use bunq\Exception\BunqException;
-use function GuzzleHttp\Psr7\parse_query;
+use GuzzleHttp\Psr7\Query;
 
 /**
  */
@@ -123,7 +123,7 @@ class Pagination
 
         if (!is_null($url)) {
             $urlQuery = parse_url($url, PHP_URL_QUERY);
-            $parameters = parse_query($urlQuery);
+            $parameters = Query::parse($urlQuery);
             $paginationBody[$idField] = $parameters[$responseParam];
 
             if (isset($parameters[self::PARAM_COUNT]) && !isset($paginationBody[self::PARAM_COUNT])) {


### PR DESCRIPTION
[//]: # (Thanks for opening this pull request! Before you proceed please make sure that you have an issue that explains what this pull request will do.
         Make sure that all your commits link to this issue e.g. "My commit. \(bunq/sdk_php#<issue nr>\)".
         If this pull request is changing files that are located in "src/Model/Generated" then this pull request will be closed as these files must/can only be changed on bunq's side.)
         
## This PR closes/fixes the following issues:
[//]: # (If for some reason your pull request does not require a test case you can just mark this box as checked and explain why it does not require a test case.)
 - Closes bunq/sdk_php#217
    - [X] Tested
 - Also solves bunq/sdk_php#218 in a imo better way (fixing it and not working around it)
    - [X] Tested

I already used this locally while development, but I rather use a official release when deploying, instead of fiddling around manually.