### PR TITLE
remove incorrect redundant check for response-id header

### DIFF
--- a/src/Http/Handler/ResponseHandlerError.php
+++ b/src/Http/Handler/ResponseHandlerError.php
@@ -110,11 +110,7 @@ class ResponseHandlerError extends ResponseHandlerBase
      */
     private function getResponseId(ResponseInterface $response): string
     {
-        $header = $response->getHeader(self::HEADER_BUNQ_CLIENT_RESPONSE_ID_UPPER_CASED);
-
-        if (empty($header)) {
-            $header = $response->getHeader(self::HEADER_BUNQ_CLIENT_RESPONSE_ID_UPPER_CASED);
-        }
+        $header = $response->getHeader(self::HEADER_BUNQ_CLIENT_RESPONSE_ID_LOWER_CASED);
 
         if (empty($header)) {
             return self::ERROR_COULD_NOT_DETERMINE_RESPONSE_ID_HEADER;


### PR DESCRIPTION
ResponseInterface hasHeader() is case-insensitive and checking for UPPER_CASED twice does not help.

[//]: # (Thanks for opening this pull request! Before you proceed please make sure that you have an issue that explains what this pull request will do.
         Make sure that all your commits link to this issue e.g. "My commit. \(bunq/sdk_php#<issue nr>\)".
         If this pull request is changing files that are located in "src/Model/Generated" then this pull request will be closed as these files must/can only be changed on bunq's side.)
         
## This PR closes/fixes the following issues:
[//]: # (If for some reason your pull request does not require a test case you can just mark this box as checked and explain why it does not require a test case.)
 - Closes bunq/sdk_php#
    - [ ] Tested
