### PR TITLE
Fix: replace deprecated function parse_query

### DIFF
--- a/src/Http/Pagination.php
+++ b/src/Http/Pagination.php
@@ -1,8 +1,9 @@
 <?php
 namespace bunq\Http;
 
+use GuzzleHttp\Psr7\Query;
 use bunq\Exception\BunqException;
-use function GuzzleHttp\Psr7\parse_query;
+
 
 /**
  */
@@ -123,7 +124,7 @@ class Pagination
 
         if (!is_null($url)) {
             $urlQuery = parse_url($url, PHP_URL_QUERY);
-            $parameters = parse_query($urlQuery);
+            $parameters = Query::parse($urlQuery);
             $paginationBody[$idField] = $parameters[$responseParam];
 
             if (isset($parameters[self::PARAM_COUNT]) && !isset($paginationBody[self::PARAM_COUNT])) {


### PR DESCRIPTION
The parse_query function has been removed in Guzzle 7.2, Query::parse is available in the Guzzle/Psr7 library and is the suggested alternative.

Should still work with Guzzle 6.

[//]: # (Thanks for opening this pull request! Before you proceed please make sure that you have an issue that explains what this pull request will do.
         Make sure that all your commits link to this issue e.g. "My commit. \(bunq/sdk_php#<issue nr>\)".
         If this pull request is changing files that are located in "src/Model/Generated" then this pull request will be closed as these files must/can only be changed on bunq's side.)
         
## This PR closes/fixes the following issues:
[//]: # (If for some reason your pull request does not require a test case you can just mark this box as checked and explain why it does not require a test case.)
 - Closes bunq/sdk_php#
    - [x] Tested
