### PR TITLE
Update ResponseHandlerSignature.php

### DIFF
--- a/src/Http/Handler/ResponseHandlerSignature.php
+++ b/src/Http/Handler/ResponseHandlerSignature.php
@@ -168,7 +168,7 @@ class ResponseHandlerSignature extends ResponseHandlerBase
         if ($regexResult != self::REGEX_CHECK_FAILED) {
             foreach ($matches[self::INDEX_FIRST] as $match) {
                 $matchUpper = strtoupper($match);
-                $headerName = preg_replace(vsprintf(self::REGEX_REPLACE, $match), $matchUpper, $headerName);
+                $headerName = preg_replace(sprintf(self::REGEX_REPLACE, $match), $matchUpper, $headerName);
             }
         }
 


### PR DESCRIPTION
apply proper string replacement function

[//]: # (Thanks for opening this pull request! Before you proceed please make sure that you have an issue that explains what this pull request will do.
         Make sure that all your commits link to this issue e.g. "My commit. \(bunq/sdk_php#<issue nr>\)".
         If this pull request is changing files that are located in "src/Model/Generated" then this pull request will be closed as these files must/can only be changed on bunq's side.)
         
## This PR closes/fixes the following issues:
[//]: # (If for some reason your pull request does not require a test case you can just mark this box as checked and explain why it does not require a test case.)
 - When you get a response from bunq with improperly formatted headers, the code breaks because you are passing a string to vsprintf. I got the error with the header `Access-control-allow-origin`. I'm suprised no one ever spotted this until now. Or you never communicated improperly formatted headers until now, and the error never surfaced. 
