### PR TITLE
rename Resource to resource so that the case sensitive environments can find the files in the resource path

### DIFF
--- a/tests/Config.php
+++ b/tests/Config.php
@@ -12,7 +12,7 @@ class Config
     /**
      * The path where the config.json file is stored
      */
-    const CONFIG_PATH = '/Resource/config.json';
+    const CONFIG_PATH = '/resource/config.json';
 
     /**
      * Delimiter between the IP addresses in the PERMITTED_IPS field.

--- a/tests/Context/Psd2ApiContextTest.php
+++ b/tests/Context/Psd2ApiContextTest.php
@@ -20,11 +20,11 @@ class Psd2ApiContextTest extends TestCase
     /**
      * File constants.
      */
-    const FILE_TEST_CONFIGURATION = __DIR__ . '/../Resource/bunq-psd2-test.conf';
-    const FILE_TEST_OAUTH = __DIR__ . '/../Resource/bunq-oauth-test.conf';
-    const FILE_TEST_CERTIFICATE = __DIR__ . '/../Resource/certificate.cert';
-    const FILE_TEST_CERTIFICATE_CHAIN = __DIR__ . '/../Resource/certificate.cert';
-    const FILE_TEST_PRIVATE_KEY = __DIR__ . '/../Resource/key.pem';
+    const FILE_TEST_CONFIGURATION = __DIR__ . '/../resource/bunq-psd2-test.conf';
+    const FILE_TEST_OAUTH = __DIR__ . '/../resource/bunq-oauth-test.conf';
+    const FILE_TEST_CERTIFICATE = __DIR__ . '/../resource/certificate.cert';
+    const FILE_TEST_CERTIFICATE_CHAIN = __DIR__ . '/../resource/certificate.cert';
+    const FILE_TEST_PRIVATE_KEY = __DIR__ . '/../resource/key.pem';
 
     const TEST_DEVICE_DESCRIPTION = 'PSD2TestDevice';
     

--- a/tests/JsonParserTest.php
+++ b/tests/JsonParserTest.php
@@ -36,8 +36,8 @@ class JsonParserTest extends TestCase
     /**
      * Resource location constants.
      */
-    const RESOURCE_INSTALLATION_JSON = '/Resource/installation.json';
-    const RESOURCE_USER_COMPANY_JSON = '/Resource/user_company.json';
+    const RESOURCE_INSTALLATION_JSON = '/resource/installation.json';
+    const RESOURCE_USER_COMPANY_JSON = '/resource/user_company.json';
 
     /**
      * Function constants.

--- a/tests/Model/Generated/Endpoint/AttachmentPublicTest.php
+++ b/tests/Model/Generated/Endpoint/AttachmentPublicTest.php
@@ -17,7 +17,7 @@ class AttachmentPublicTest extends BunqSdkTestBase
     /**
      *  Points to the folder where attachments are located.
      */
-    const PATH_ATTACHMENT = '/../../../Resource/';
+    const PATH_ATTACHMENT = '/../../../resource/';
 
     /**
      * Check if the file send is indeed the same file we receive.

--- a/tests/Model/Generated/Endpoint/AvatarTest.php
+++ b/tests/Model/Generated/Endpoint/AvatarTest.php
@@ -23,7 +23,7 @@ class AvatarTest extends BunqSdkTestBase
     /**
      *  Points to the directory where attachments are stored.
      */
-    const PATH_ATTACHMENT = '/../../../Resource/';
+    const PATH_ATTACHMENT = '/../../../resource/';
 
     /**
      * Tests the creation of a new avatar.

--- a/tests/Model/Generated/Object/NotificationUrlTest.php
+++ b/tests/Model/Generated/Object/NotificationUrlTest.php
@@ -53,7 +53,7 @@ class NotificationUrlTest extends BunqSdkTestBase
     /**
      * Model json paths constants.
      */
-    const BASE_PATH_JSON_MODEL = __DIR__ . '/../../../Resource/NotificationUrlJsons';
+    const BASE_PATH_JSON_MODEL = __DIR__ . '/../../../resource/NotificationUrlJsons';
     const JSON_PATH_MUTATION_MODEL = self::BASE_PATH_JSON_MODEL . '/Mutation.json';
     const JSON_PATH_BUNQ_ME_TAB_MODEL = self::BASE_PATH_JSON_MODEL . '/BunqMeTab.json';
     const JSON_PATH_CHAT_MESSAGE_ANNOUNCEMENT_MODEL = self::BASE_PATH_JSON_MODEL . '/ChatMessageAnnouncement.json';


### PR DESCRIPTION
rename Resource to resource so that the case sensitive environments can find the files in the resource path